### PR TITLE
fix: update to unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {

--- a/packages/i3status-rs.nix
+++ b/packages/i3status-rs.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-ZUgdHfXl3Y5XXkZFgTRb2cW9rdv/FpgLoDliSUIYXtI=";
   };
 
-  cargoHash = "sha256-D47CnaPLNFI071uwR99K77xo5hn+xvPltYlUJGcW1DM=";
+  cargoHash = "sha256-1fpT5BPdmUE8saQED62NlPc6zOVNkaa1zaO7ZIuXnWc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/packages/regolith-displayd.nix
+++ b/packages/regolith-displayd.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-WUjUs9h+zzq9lFqnEHvsCJ322HVPZldUOt0LZdKbUFs=";
   };
 
-  cargoHash = "sha256-SJ99TqEMMyDGqDwJ3x7EJ/jXe0iNvctTJcPnO5uVXW0=";
+  cargoHash = "sha256-uA7h4nMpYtqtZGm1ifTVRrEfkcKjysdqL25VXqhJekk=";
 
   postInstall = ''
     install -Dm644 data/regolith-init-kanshi.service $out/lib/systemd/user/regolith-init-kanshi.service

--- a/packages/regolith-inputd.nix
+++ b/packages/regolith-inputd.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-PX9lWeAfJ79zEhXEKFTryf780JcoY7k6XRSxzHM1WWw=";
   };
 
-  cargoHash = "sha256-6dlpuQSfxFnam4F5QSoqs1vi7EqY8MraRkTm4iQUSR4=";
+  cargoHash = "sha256-B/lAyjU1vMZKgg+fRvOm0QfVEKyaZHMexvxraI5f17I=";
 
   nativeBuildInputs = [
     pkg-config

--- a/packages/regolith-powerd.nix
+++ b/packages/regolith-powerd.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Hu6EhNBClHsh0mrOAfPw848q0czoivoYnpiE9/+drK4=";
   };
 
-  cargoHash = "sha256-mVs3g7ccAGST53I4/7daOm8EJKdKh0mJGhCPFX6rfhs=";
+  cargoHash = "sha256-HHnilpOW1bnhxFqy5l5+FPO8Qp5zSAE/k14unK/gEig=";
 
   nativeBuildInputs = [
     pkg-config

--- a/packages/trawl.nix
+++ b/packages/trawl.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-/nUvV0tgPzOJ5L+EXw6J/1lgRT+BPnlkv7yzko15o6A";
   };
 
-  cargoHash = "sha256-5kDWFJ6kmzrs5U1uOfmGTLE+z8DGcS+BIv8ZIUU4StA=";
+  cargoHash = "sha256-TXdqphvt55PkTiXXjftSRkoMyEyBW0x0csjNPruYtoo=";
 
   postInstall = ''
     mkdir -p $out/lib/systemd/user

--- a/sway-regolith/01-regolith-trawl.patch
+++ b/sway-regolith/01-regolith-trawl.patch
@@ -1,15 +1,3 @@
-Index: sway-regolith/include/sway/commands.h
-===================================================================
---- sway-regolith.orig/include/sway/commands.h
-+++ sway-regolith/include/sway/commands.h
-@@ -172,6 +172,7 @@ sway_cmd cmd_resize;
- sway_cmd cmd_scratchpad;
- sway_cmd cmd_seamless_mouse;
- sway_cmd cmd_set;
-+sway_cmd cmd_set_from_resource;
- sway_cmd cmd_shortcuts_inhibitor;
- sway_cmd cmd_show_marks;
- sway_cmd cmd_smart_borders;
 Index: sway-regolith/meson.build
 ===================================================================
 --- sway-regolith.orig/meson.build
@@ -19,85 +7,16 @@ Index: sway-regolith/meson.build
 -	'sway',
 +	'sway-regolith',
  	'c',
- 	version: '1.9',
+ 	version: '1.10.1',
  	license: 'MIT',
-@@ -45,6 +45,27 @@ subproject(
- 	version: wlroots_version,
- )
- wlroots = dependency('wlroots', version: wlroots_version)
-+xkbcommon = dependency('xkbcommon')
-+cairo = dependency('cairo')
-+pango = dependency('pango')
-+pangocairo = dependency('pangocairo')
-+gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
-+pixman = dependency('pixman-1')
-+glesv2 = dependency('glesv2')
-+libevdev = dependency('libevdev')
-+libinput = dependency('libinput', version: '>=1.6.0')
-+xcb = dependency('xcb', required: get_option('xwayland'))
-+drm_full = dependency('libdrm') # only needed for drm_fourcc.h
-+drm = drm_full.partial_dependency(compile_args: true, includes: true)
-+libudev = dependency('libudev')
-+bash_comp = dependency('bash-completion', required: false)
-+fish_comp = dependency('fish', required: false)
-+math = cc.find_library('m')
-+rt = cc.find_library('rt')
-+xcb_icccm = dependency('xcb-icccm', required: get_option('xwayland'))
-+threads = dependency('threads') # for pthread_setschedparam
+@@ -80,6 +80,7 @@ math = cc.find_library('m')
+ rt = cc.find_library('rt')
+ xcb_icccm = wlroots_features['xwayland'] ? dependency('xcb-icccm') : null_dep
+ threads = dependency('threads') # for pthread_setschedparam
 +trawldb = dependency('trawldb-0')
-+
- wlroots_features = {
- 	'xwayland': false,
- 	'libinput_backend': false,
-Index: sway-regolith/sway/commands.c
-===================================================================
---- sway-regolith.orig/sway/commands.c
-+++ sway-regolith/sway/commands.c
-@@ -84,6 +84,7 @@ static const struct cmd_handler handlers
- 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
- 	{ "seat", cmd_seat },
- 	{ "set", cmd_set },
-+	{ "set_from_resource", cmd_set_from_resource},
- 	{ "show_marks", cmd_show_marks },
- 	{ "smart_borders", cmd_smart_borders },
- 	{ "smart_gaps", cmd_smart_gaps },
-@@ -279,8 +280,8 @@ list_t *execute_command(char *_exec, str
- 			goto cleanup;
- 		}
  
--		// Var replacement, for all but first argument of set
--		for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
-+		// Var replacement, for all but first argument of set and xresource
-+		for (int i = handler->handle == cmd_set || handler->handle == cmd_set_from_resource ? 2 : 1; i < argc; ++i) {
- 			argv[i] = do_var_replacement(argv[i]);
- 		}
- 
-@@ -392,7 +393,7 @@ struct cmd_results *config_command(char
- 	}
- 
- 	// Do variable replacement
--	if (handler->handle == cmd_set && argc > 1 && *argv[1] == '$') {
-+	if ((handler->handle == cmd_set || handler->handle == cmd_set_from_resource )&& argc > 1 && *argv[1] == '$') {
- 		// Escape the variable name so it does not get replaced by one shorter
- 		char *temp = calloc(1, strlen(argv[1]) + 2);
- 		temp[0] = '$';
-@@ -407,7 +408,7 @@ struct cmd_results *config_command(char
- 	free(command);
- 
- 	// Strip quotes and unescape the string
--	for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
-+	for (int i = handler->handle == cmd_set || handler->handle == cmd_set_from_resource ? 2 : 1; i < argc; ++i) {
- 		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
- 				&& handler->handle != cmd_mode
- 				&& handler->handle != cmd_bindsym
-@@ -415,6 +416,7 @@ struct cmd_results *config_command(char
- 				&& handler->handle != cmd_bindswitch
- 				&& handler->handle != cmd_bindgesture
- 				&& handler->handle != cmd_set
-+				&& handler->handle != cmd_set_from_resource
- 				&& handler->handle != cmd_for_window
- 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
- 			strip_quotes(argv[i]);
+ if get_option('sd-bus-provider') == 'auto'
+ 	if not get_option('tray').disabled()
 Index: sway-regolith/sway/commands/set_from_resource.c
 ===================================================================
 --- /dev/null
@@ -150,11 +69,72 @@ Index: sway-regolith/sway/commands/set_from_resource.c
 +  free(resource_value);
 +  return cmd_set(2, argv_new);
 +}
+Index: sway-regolith/include/sway/commands.h
+===================================================================
+--- sway-regolith.orig/include/sway/commands.h
++++ sway-regolith/include/sway/commands.h
+@@ -173,6 +173,7 @@ sway_cmd cmd_resize;
+ sway_cmd cmd_scratchpad;
+ sway_cmd cmd_seamless_mouse;
+ sway_cmd cmd_set;
++sway_cmd cmd_set_from_resource;
+ sway_cmd cmd_shortcuts_inhibitor;
+ sway_cmd cmd_show_marks;
+ sway_cmd cmd_smart_borders;
+Index: sway-regolith/sway/commands.c
+===================================================================
+--- sway-regolith.orig/sway/commands.c
++++ sway-regolith/sway/commands.c
+@@ -83,6 +83,7 @@ static const struct cmd_handler handlers
+ 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+ 	{ "seat", cmd_seat },
+ 	{ "set", cmd_set },
++	{ "set_from_resource", cmd_set_from_resource },
+ 	{ "show_marks", cmd_show_marks },
+ 	{ "smart_borders", cmd_smart_borders },
+ 	{ "smart_gaps", cmd_smart_gaps },
+@@ -279,8 +280,8 @@ list_t *execute_command(char *_exec, str
+ 			goto cleanup;
+ 		}
+ 
+-		// Var replacement, for all but first argument of set
+-		for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
++		// Var replacement, for all but first argument of set and xresource
++		for (int i = handler->handle == cmd_set || handler->handle == cmd_set_from_resource ? 2 : 1; i < argc; ++i) {
+ 			argv[i] = do_var_replacement(argv[i]);
+ 		}
+ 
+@@ -392,7 +393,7 @@ struct cmd_results *config_command(char
+ 	}
+ 
+ 	// Do variable replacement
+-	if (handler->handle == cmd_set && argc > 1 && *argv[1] == '$') {
++	if ((handler->handle == cmd_set || handler->handle == cmd_set_from_resource )&& argc > 1 && *argv[1] == '$') {
+ 		// Escape the variable name so it does not get replaced by one shorter
+ 		char *temp = calloc(1, strlen(argv[1]) + 2);
+ 		temp[0] = '$';
+@@ -407,7 +408,7 @@ struct cmd_results *config_command(char
+ 	free(command);
+ 
+ 	// Strip quotes and unescape the string
+-	for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
++	for (int i = handler->handle == cmd_set || handler->handle == cmd_set_from_resource ? 2 : 1; i < argc; ++i) {
+ 		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
+ 				&& handler->handle != cmd_mode
+ 				&& handler->handle != cmd_bindsym
+@@ -415,6 +416,7 @@ struct cmd_results *config_command(char
+ 				&& handler->handle != cmd_bindswitch
+ 				&& handler->handle != cmd_bindgesture
+ 				&& handler->handle != cmd_set
++				&& handler->handle != cmd_set_from_resource
+ 				&& handler->handle != cmd_for_window
+ 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
+ 			strip_quotes(argv[i]);
 Index: sway-regolith/sway/meson.build
 ===================================================================
 --- sway-regolith.orig/sway/meson.build
 +++ sway-regolith/sway/meson.build
-@@ -102,6 +102,7 @@ sway_sources = files(
+@@ -103,6 +103,7 @@ sway_sources = files(
  	'commands/seat/shortcuts_inhibitor.c',
  	'commands/seat/xcursor_theme.c',
  	'commands/set.c',
@@ -162,11 +142,11 @@ Index: sway-regolith/sway/meson.build
  	'commands/show_marks.c',
  	'commands/shortcuts_inhibitor.c',
  	'commands/smart_borders.c',
-@@ -230,6 +231,7 @@ sway_deps = [
+@@ -234,6 +235,7 @@ sway_deps = [
  	xkbcommon,
  	xcb,
  	xcb_icccm,
 +	trawldb,
  ]
  
- if have_xwayland
+ if wlroots_features['xwayland']

--- a/sway-regolith/02-version-fix.patch
+++ b/sway-regolith/02-version-fix.patch
@@ -2,14 +2,14 @@ Index: sway-regolith/meson.build
 ===================================================================
 --- sway-regolith.orig/meson.build
 +++ sway-regolith/meson.build
-@@ -186,18 +186,6 @@ endif
+@@ -157,18 +156,18 @@ endif
  add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
  
  version = '"@0@"'.format(meson.project_version())
 -git = find_program('git', native: true, required: false)
 -if git.found()
--	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: false)
--	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
+-	git_commit = run_command([git, '--git-dir=.git', 'rev-parse', '--short', 'HEAD'], check: false)
+-	git_branch = run_command([git, '--git-dir=.git', 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
 -	if git_commit.returncode() == 0 and git_branch.returncode() == 0
 -		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
 -			meson.project_version(),
@@ -18,6 +18,18 @@ Index: sway-regolith/meson.build
 -		)
 -	endif
 -endif
++# git = find_program('git', native: true, required: false)
++# if git.found()
++# 	git_commit = run_command([git, '--git-dir=.git', 'rev-parse', '--short', 'HEAD'], check: false)
++# 	git_branch = run_command([git, '--git-dir=.git', 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
++# 	if git_commit.returncode() == 0 and git_branch.returncode() == 0
++# 		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
++# 			meson.project_version(),
++# 			git_commit.stdout().strip(),
++# 			git_branch.stdout().strip(),
++# 		)
++# 	endif
++# endif
  add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
  
  # Compute the relative path used by compiler invocations.

--- a/sway-regolith/04-dbus-tray
+++ b/sway-regolith/04-dbus-tray
@@ -71,7 +71,7 @@ Index: sway-regolith/swaybar/bar.c
 ===================================================================
 --- sway-regolith.orig/swaybar/bar.c
 +++ sway-regolith/swaybar/bar.c
-@@ -29,6 +29,7 @@
+@@ -28,6 +28,7 @@
  #include "pool-buffer.h"
  #include "wlr-layer-shell-unstable-v1-client-protocol.h"
  #include "xdg-output-unstable-v1-client-protocol.h"
@@ -79,7 +79,7 @@ Index: sway-regolith/swaybar/bar.c
  
  void free_workspaces(struct wl_list *list) {
  	struct swaybar_workspace *ws, *tmp;
-@@ -365,6 +366,8 @@ static void handle_global(void *data, st
+@@ -364,6 +365,8 @@ static void handle_global(void *data, st
  	} else if (strcmp(interface, wp_cursor_shape_manager_v1_interface.name) == 0) {
  		bar->cursor_shape_manager = wl_registry_bind(registry, name,
  			&wp_cursor_shape_manager_v1_interface, 1);
@@ -88,7 +88,7 @@ Index: sway-regolith/swaybar/bar.c
  	}
  }
  
-@@ -539,6 +542,7 @@ void bar_teardown(struct swaybar *bar) {
+@@ -538,6 +541,7 @@ void bar_teardown(struct swaybar *bar) {
  #if HAVE_TRAY
  	destroy_tray(bar->tray);
  #endif
@@ -264,7 +264,7 @@ Index: sway-regolith/swaybar/render.c
  		double x, double y, uint32_t button, bool released, void *data) {
  	struct i3bar_block *block = data;
  	struct status_line *status = output->bar->status;
-@@ -599,6 +600,7 @@ static uint32_t render_binding_mode_indi
+@@ -601,6 +602,7 @@ static uint32_t render_binding_mode_indi
  
  static enum hotspot_event_handling workspace_hotspot_callback(
  		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
@@ -277,14 +277,14 @@ Index: sway-regolith/swaybar/tray/item.c
 --- sway-regolith.orig/swaybar/tray/item.c
 +++ sway-regolith/swaybar/tray/item.c
 @@ -8,6 +8,7 @@
- #include "swaybar/bar.h"
  #include "swaybar/config.h"
+ #include "swaybar/image.h"
  #include "swaybar/input.h"
 +#include "swaybar/tray/dbusmenu.h"
  #include "swaybar/tray/host.h"
  #include "swaybar/tray/icon.h"
  #include "swaybar/tray/item.h"
-@@ -333,8 +334,9 @@ void destroy_sni(struct swaybar_sni *sni
+@@ -332,8 +333,9 @@ void destroy_sni(struct swaybar_sni *sni
  	free(sni);
  }
  
@@ -296,7 +296,7 @@ Index: sway-regolith/swaybar/tray/item.c
  	const char *method = NULL;
  	struct tray_binding *binding = NULL;
  	wl_list_for_each(binding, &sni->tray->bar->config->tray_bindings, link) {
-@@ -365,7 +367,11 @@ static void handle_click(struct swaybar_
+@@ -364,7 +366,11 @@ static void handle_click(struct swaybar_
  		method = "ContextMenu";
  	}
  
@@ -309,7 +309,7 @@ Index: sway-regolith/swaybar/tray/item.c
  		char dir = method[strlen("Scroll")];
  		char *orientation = (dir == 'U' || dir == 'D') ? "vertical" : "horizontal";
  		int sign = (dir == 'U' || dir == 'L') ? -1 : 1;
-@@ -385,6 +391,7 @@ static int cmp_sni_id(const void *item,
+@@ -384,6 +390,7 @@ static int cmp_sni_id(const void *item,
  
  static enum hotspot_event_handling icon_hotspot_callback(
  		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
@@ -317,7 +317,7 @@ Index: sway-regolith/swaybar/tray/item.c
  		double x, double y, uint32_t button, bool released, void *data) {
  	sway_log(SWAY_DEBUG, "Clicked on %s", (char *)data);
  
-@@ -406,7 +413,8 @@ static enum hotspot_event_handling icon_
+@@ -405,7 +412,8 @@ static enum hotspot_event_handling icon_
  				(int) output->output_height - config->gaps.bottom - y);
  
  		sway_log(SWAY_DEBUG, "Guessing click position at (%d, %d)", global_x, global_y);
@@ -331,7 +331,7 @@ Index: sway-regolith/swaybar/tray/tray.c
 ===================================================================
 --- sway-regolith.orig/swaybar/tray/tray.c
 +++ sway-regolith/swaybar/tray/tray.c
-@@ -110,7 +110,7 @@ static int cmp_output(const void *item,
+@@ -118,7 +118,7 @@ static int cmp_output(const void *item,
  
  uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
  	struct swaybar_config *config = output->bar->config;
@@ -376,7 +376,7 @@ Index: sway-regolith/swaybar/tray/dbusmenu.c
 ===================================================================
 --- /dev/null
 +++ sway-regolith/swaybar/tray/dbusmenu.c
-@@ -0,0 +1,1367 @@
+@@ -0,0 +1,1348 @@
 +#define _POSIX_C_SOURCE 200809L
 +#include <linux/input-event-codes.h>
 +#include <pool-buffer.h>
@@ -388,7 +388,6 @@ Index: sway-regolith/swaybar/tray/dbusmenu.c
 +#include <xdg-shell-client-protocol.h>
 +#include <xdg-shell-protocol.h>
 +
-+#include "background-image.h"
 +#include "cairo.h"
 +#include "cairo_util.h"
 +#include "list.h"
@@ -788,25 +787,7 @@ Index: sway-regolith/swaybar/tray/dbusmenu.c
 +				if (sni->icon_theme_path) {
 +					list_add(icon_search_paths, sni->icon_theme_path);
 +				}
-+				int min_size, max_size;
-+				char *icon_path =
-+				find_icon(tray->themes, icon_search_paths, item->icon_name, size,
-+						config->icon_theme, &min_size, &max_size);
 +				list_free(icon_search_paths);
-+
-+				if (icon_path) {
-+					cairo_surface_t *icon = load_background_image(icon_path);
-+					free(icon_path);
-+					cairo_surface_t *icon_scaled =
-+					cairo_image_surface_scale(icon, size, size);
-+					cairo_surface_destroy(icon);
-+
-+					cairo_set_source_surface(cairo, icon_scaled, x, y);
-+					cairo_rectangle(cairo, x, y, size, size);
-+					cairo_fill(cairo);
-+					cairo_surface_destroy(icon_scaled);
-+					is_icon_drawn = true;
-+				}
 +			} else if (item->icon_data) {
 +				cairo_surface_t *icon = cairo_image_surface_scale(item->icon_data, size, size);
 +				cairo_set_source_surface(cairo, icon, x, y);

--- a/sway-regolith/05-remove-config
+++ b/sway-regolith/05-remove-config
@@ -2,7 +2,7 @@ Index: sway-regolith/meson.build
 ===================================================================
 --- sway-regolith.orig/meson.build
 +++ sway-regolith/meson.build
-@@ -244,23 +244,6 @@ if get_option('swaynag')
+@@ -226,23 +226,6 @@ if get_option('swaynag')
  	subdir('swaynag')
  endif
  

--- a/sway-regolith/default.nix
+++ b/sway-regolith/default.nix
@@ -1,75 +1,80 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, substituteAll
-, swaybg
-, meson
-, ninja
-, pkg-config
-, wayland-scanner
-, scdoc
-, libGL
-, wayland
-, libxkbcommon
-, pcre2
-, json_c
-, libevdev
-, pango
-, cairo
-, libinput
-, gdk-pixbuf
-, librsvg
-, wlroots_0_17
-, wayland-protocols
-, libdrm
-, nixosTests
-, pkgs
-, makeWrapper
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  replaceVars,
+  swaybg,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  scdoc,
+  libGL,
+  wayland,
+  libxkbcommon,
+  pcre2,
+  json_c,
+  libevdev,
+  pango,
+  cairo,
+  libinput,
+  gdk-pixbuf,
+  librsvg,
+  wlroots_0_18,
+  wayland-protocols,
+  libdrm,
+  nixosTests,
   # Used by the NixOS module:
-, isNixOS ? false
-, enableXWayland ? true
-, xorg
-, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
-, systemd
-, trayEnabled ? systemdSupport
+  isNixOS ? false,
+  enableXWayland ? true,
+  xorg,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
+  trayEnabled ? systemdSupport,
 }:
 let
-  libtrawldb = pkgs.callPackage ../packages/libtrawldb.nix { };
+  libtrawldb = callPackage ../packages/libtrawldb.nix { };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sway-unwrapped";
-  version = "1.9";
+  version = "1.10.1";
 
-  inherit enableXWayland isNixOS systemdSupport trayEnabled;
+  inherit
+    enableXWayland
+    isNixOS
+    systemdSupport
+    trayEnabled
+    ;
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = finalAttrs.version;
-    hash = "sha256-/6+iDkQfdLcL/pTJaqNc6QdP4SRVOYLjfOItEu/bZtg=";
+    hash = "sha256-uBtQk8uhW/i8lSbv6zwsRyiiImFBw1YCQHVWQ8jot5w=";
   };
 
-  patches = [
-    ./01-regolith-trawl.patch
-    ./load-configuration-from-etc.patch
-    ./02-version-fix.patch
-    ./03-disable-wallpaper
-    ./04-dbus-tray
-    ./05-remove-config
-
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit swaybg;
-    })
-
-  ] ++ lib.optionals (!finalAttrs.isNixOS) [
-    # References to /nix/store/... will get GC'ed which causes problems when
-    # copying the default configuration:
-    ./sway-config-no-nix-store-references.patch
-  ] ++ lib.optionals finalAttrs.isNixOS [
-    # Use /run/current-system/sw/share and /etc instead of /nix/store
-    # references:
-    ./sway-config-nixos-paths.patch
-  ];
+  patches =
+    [
+      ./01-regolith-trawl.patch
+      ./load-configuration-from-etc.patch
+      ./02-version-fix.patch
+      # ./03-disable-wallpaper
+      ./04-dbus-tray
+      ./05-remove-config
+      (replaceVars ./fix-paths.patch {
+        inherit swaybg;
+      })
+    ]
+    ++ lib.optionals (!finalAttrs.isNixOS) [
+      # References to /nix/store/... will get GC'ed which causes problems when
+      # copying the default configuration:
+      ./sway-config-no-nix-store-references.patch
+    ]
+    ++ lib.optionals finalAttrs.isNixOS [
+      # Use /run/current-system/sw/share and /etc instead of /nix/store
+      # references:
+      ./sway-config-nixos-paths.patch
+    ];
 
   strictDeps = true;
   depsBuildBuild = [
@@ -77,37 +82,41 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    libtrawldb
     meson
     ninja
     pkg-config
     wayland-scanner
     scdoc
-    makeWrapper
   ];
 
-  buildInputs = [
-    libGL
-    wayland
-    libxkbcommon
-    pcre2
-    json_c
-    libevdev
-    pango
-    cairo
-    libinput
-    gdk-pixbuf
-    librsvg
-    wayland-protocols
-    libdrm
-    (wlroots_0_17.override { inherit (finalAttrs) enableXWayland; })
-  ] ++ lib.optionals finalAttrs.enableXWayland [
-    xorg.xcbutilwm
-  ];
+  buildInputs =
+    [
+      libtrawldb
+      swaybg
+      libGL
+      wayland
+      libxkbcommon
+      pcre2
+      json_c
+      libevdev
+      pango
+      cairo
+      libinput
+      gdk-pixbuf
+      librsvg
+      wayland-protocols
+      libdrm
+      (wlroots_0_18.override { inherit (finalAttrs) enableXWayland; })
+    ]
+    ++ lib.optionals finalAttrs.enableXWayland [
+      xorg.xcbutilwm
+    ];
 
-  runtimeDependencies = [
-    libtrawldb
-  ];
+    # dependencies =
+    # [
+    #   libtrawldb
+    #   swaybg
+    # ];
 
   mesonFlags =
     let
@@ -123,23 +132,13 @@ stdenv.mkDerivation (finalAttrs: {
     in
     [
       (mesonOption "sd-bus-provider" sd-bus-provider)
-      (mesonEnable "xwayland" finalAttrs.enableXWayland)
       (mesonEnable "tray" finalAttrs.trayEnabled)
     ];
 
   passthru.tests.basic = nixosTests.sway;
 
-  postFixup =
-    let
-      libraryPath = lib.makeLibraryPath [ libtrawldb ];
-    in
-    ''
-      wrapProgram $out/bin/sway \
-        --prefix LD_LIBRARY_PATH : "${libraryPath}"
-    '';
-
   meta = {
-    description = "An i3-compatible tiling Wayland compositor";
+    description = "I3-compatible tiling Wayland compositor";
     longDescription = ''
       Sway is a tiling Wayland compositor and a drop-in replacement for the i3
       window manager for X11. It works with your existing i3 configuration and
@@ -153,7 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/swaywm/sway/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos synthetica ];
+    maintainers = with lib.maintainers; [
+      primeos
+      synthetica
+    ];
     mainProgram = "sway";
   };
 })


### PR DESCRIPTION
This updates the repository to latest nixpkgs. 
a. Updates sway-regolith to 1.10.1 and patches
b. fix hashes in regolith-inputd | regolith-powerd| regolith-displayd| i3status-rs
c. module to include the correct binary path